### PR TITLE
Move out of Nerves namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/fhunleth/nerves_time.svg?style=svg)](https://circleci.com/gh/fhunleth/nerves_time)
 [![Hex version](https://img.shields.io/hexpm/v/nerves_time.svg "Hex version")](https://hex.pm/packages/nerves_time)
 
-`Nerves.Time` keeps the system clock on [Nerves](http://nerves-project.org)
+`NervesTime` keeps the system clock on [Nerves](http://nerves-project.org)
 devices in sync when connected to the network and close to in sync when
 disconnected. It's especially useful for devices lacking a [Battery-backed
 real-time clock](https://en.wikipedia.org/wiki/Real-time_clock) and will advance
@@ -54,7 +54,7 @@ config :nerves_time, :servers, [
 ```
 
 It's also possible to configure NTP servers at runtime. See
-`Nerves.Time.set_ntp_servers/1`.
+`NervesTime.set_ntp_servers/1`.
 
 ## Algorithm
 
@@ -70,7 +70,7 @@ Here's the basic idea behind `nerves_time`:
   currently only done at around 11 minute intervals to avoid needless exercising
   of Flash-based memory.
 
-To check the NTP synchronization status, call `Nerves.Time.synchronized?/0`.
+To check the NTP synchronization status, call `NervesTime.synchronized?/0`.
 
 ## Credits and license
 

--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -1,6 +1,6 @@
-defmodule Nerves.Time do
+defmodule NervesTime do
   @moduledoc """
-  `Nerves.Time` keeps the system clock on [Nerves](http://nerves-project.org)
+  `NervesTime` keeps the system clock on [Nerves](http://nerves-project.org)
   devices in sync when connected to the network and close to in sync when
   disconnected. It's especially useful for devices lacking a [Battery-backed
   real-time clock](https://en.wikipedia.org/wiki/Real-time_clock) and will
@@ -11,12 +11,12 @@ defmodule Nerves.Time do
   Check whether NTP is synchronized with the configured NTP servers.
 
   It's possible that the time is already set correctly when this returns false.
-  `Nerves.Time` decides that NTP is synchronized when `ntpd` sends a
+  `NervesTime` decides that NTP is synchronized when `ntpd` sends a
   notification that the device's clock stratum is 4 or less. Clock adjustments
   occur before this, though.
   """
   @spec synchronized?() :: boolean()
-  defdelegate synchronized?, to: Nerves.Time.Ntpd
+  defdelegate synchronized?, to: NervesTime.Ntpd
 
   @doc """
   Set the list of NTP servers.
@@ -34,7 +34,7 @@ defmodule Nerves.Time do
   ]
   ```
 
-  `Nerves.Time` uses [NTP Pool](https://www.ntppool.org/en/) by default. To
+  `NervesTime` uses [NTP Pool](https://www.ntppool.org/en/) by default. To
   disable this and configure servers solely at runtime, specify an empty list
   in `config.exs`:
 
@@ -43,18 +43,18 @@ defmodule Nerves.Time do
   ```
   """
   @spec set_ntp_servers([String.t()]) :: :ok
-  defdelegate set_ntp_servers(servers), to: Nerves.Time.Ntpd
+  defdelegate set_ntp_servers(servers), to: NervesTime.Ntpd
 
   @doc """
   Return the current NTP servers.
   """
   @spec ntp_servers() :: [String.t()] | {:error, term()}
-  defdelegate ntp_servers(), to: Nerves.Time.Ntpd
+  defdelegate ntp_servers(), to: NervesTime.Ntpd
 
   @doc """
   Manually restart the NTP daemon.
 
-  This is normally not necessary since `Nerves.Time` handles restarting it
+  This is normally not necessary since `NervesTime` handles restarting it
   automatically. An example of a reason to call this function is if you know
   when the Internet becomes available. For this case, calling `restart_ntp`
   will cancel `ntpd`'s internal timeouts and cause it to immediately send time
@@ -62,5 +62,5 @@ defmodule Nerves.Time do
   calling this function too frequently.
   """
   @spec restart_ntpd() :: :ok | {:error, term()}
-  defdelegate restart_ntpd(), to: Nerves.Time.Ntpd
+  defdelegate restart_ntpd(), to: NervesTime.Ntpd
 end

--- a/lib/nerves_time/application.ex
+++ b/lib/nerves_time/application.ex
@@ -1,30 +1,30 @@
-defmodule Nerves.Time.Application do
+defmodule NervesTime.Application do
   @moduledoc false
   require Logger
   use Application
 
   def start(_type, _args) do
     children = [
-      {Nerves.Time.Ntpd, []}
+      {NervesTime.Ntpd, []}
     ]
 
     # Sanity check and adjust the clock
     adjust_clock()
 
-    opts = [strategy: :one_for_one, name: Nerves.Time.Supervisor]
+    opts = [strategy: :one_for_one, name: NervesTime.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
   def stop(_state) do
     # Update the file that keeps track of the time one last time.
-    Nerves.Time.FileTime.update()
+    NervesTime.FileTime.update()
   end
 
   defp adjust_clock() do
-    file_time = Nerves.Time.FileTime.time()
+    file_time = NervesTime.FileTime.time()
     now = NaiveDateTime.utc_now()
 
-    case Nerves.Time.SaneTime.derive_time(now, file_time) do
+    case NervesTime.SaneTime.derive_time(now, file_time) do
       ^now ->
         # No change to the current time. This means that we either have a
         # real-time clock that sets the time or the default time that was

--- a/lib/nerves_time/file_time.ex
+++ b/lib/nerves_time/file_time.ex
@@ -1,4 +1,4 @@
-defmodule Nerves.Time.FileTime do
+defmodule NervesTime.FileTime do
   @default_path ".nerves_time"
 
   @moduledoc false

--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -1,6 +1,6 @@
-defmodule Nerves.Time.Ntpd do
+defmodule NervesTime.Ntpd do
   use GenServer
-  alias Nerves.Time.FileTime
+  alias NervesTime.FileTime
   require Logger
 
   @moduledoc false

--- a/lib/nerves_time/sane_time.ex
+++ b/lib/nerves_time/sane_time.ex
@@ -1,4 +1,4 @@
-defmodule Nerves.Time.SaneTime do
+defmodule NervesTime.SaneTime do
   @build_time NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
   @newest_time %{@build_time | year: @build_time.year + 20}
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Nerves.Time.MixProject do
+defmodule NervesTime.MixProject do
   use Mix.Project
 
   @version "0.2.1"
@@ -29,7 +29,7 @@ defmodule Nerves.Time.MixProject do
   def application do
     [
       extra_applications: [:logger],
-      mod: {Nerves.Time.Application, []}
+      mod: {NervesTime.Application, []}
     ]
   end
 

--- a/test/nerves_time_test.exs
+++ b/test/nerves_time_test.exs
@@ -1,7 +1,7 @@
 defmodule NervesTimeTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
-  doctest Nerves.Time
+  doctest NervesTime
 
   @fixtures Path.expand("fixtures", __DIR__)
   defp fixture_path(fixture) do
@@ -28,7 +28,7 @@ defmodule NervesTimeTest do
     Process.sleep(100)
 
     # The fake_busybox_ntpd should have reported synchronization by this time.
-    assert Nerves.Time.synchronized?()
+    assert NervesTime.synchronized?()
   end
 
   test "reports that time not synchronized when net is down" do
@@ -36,7 +36,7 @@ defmodule NervesTimeTest do
     Application.start(:nerves_time)
     Process.sleep(100)
 
-    refute Nerves.Time.synchronized?()
+    refute NervesTime.synchronized?()
   end
 
   test "delays ntpd restart after a GenServer crash" do
@@ -44,13 +44,13 @@ defmodule NervesTimeTest do
     Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
     Application.start(:nerves_time)
 
-    assert Nerves.Time.Ntpd.clean_start?()
+    assert NervesTime.Ntpd.clean_start?()
 
     # Kill it...
-    Process.exit(Process.whereis(Nerves.Time.Ntpd), :oops)
+    Process.exit(Process.whereis(NervesTime.Ntpd), :oops)
     Process.sleep(100)
 
-    refute Nerves.Time.Ntpd.clean_start?()
+    refute NervesTime.Ntpd.clean_start?()
   end
 
   test "delays ntpd restart after a ntpd crash" do
@@ -59,7 +59,7 @@ defmodule NervesTimeTest do
     Application.start(:nerves_time)
     Process.sleep(100)
 
-    refute Nerves.Time.Ntpd.clean_start?()
+    refute NervesTime.Ntpd.clean_start?()
 
     # Restore env.
     Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
@@ -70,22 +70,22 @@ defmodule NervesTimeTest do
     Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
     Application.start(:nerves_time)
 
-    assert Nerves.Time.Ntpd.clean_start?()
+    assert NervesTime.Ntpd.clean_start?()
 
     # Kill it...
-    Process.exit(Process.whereis(Nerves.Time.Ntpd), :oops)
+    Process.exit(Process.whereis(NervesTime.Ntpd), :oops)
     Process.sleep(100)
 
-    refute Nerves.Time.Ntpd.clean_start?()
-    refute Nerves.Time.synchronized?()
+    refute NervesTime.Ntpd.clean_start?()
+    refute NervesTime.synchronized?()
 
     # Force a restart
     # NOTE: This is actually a start, since the unclean run above will
     #       not have started ntpd yet.
-    Nerves.Time.restart_ntpd()
+    NervesTime.restart_ntpd()
 
     # This should be clean now.
-    assert Nerves.Time.Ntpd.clean_start?()
+    assert NervesTime.Ntpd.clean_start?()
   end
 
   test "can restart ntpd" do
@@ -96,19 +96,19 @@ defmodule NervesTimeTest do
     # Wait for synchronization so that we can also check that
     # synchronization goes away on restart
     Process.sleep(100)
-    assert Nerves.Time.Ntpd.clean_start?()
-    assert Nerves.Time.synchronized?()
+    assert NervesTime.Ntpd.clean_start?()
+    assert NervesTime.synchronized?()
 
     # Force a restart
-    Nerves.Time.restart_ntpd()
+    NervesTime.restart_ntpd()
 
     # Clean start, but not synchronized.
-    refute Nerves.Time.synchronized?()
-    assert Nerves.Time.Ntpd.clean_start?()
+    refute NervesTime.synchronized?()
+    assert NervesTime.Ntpd.clean_start?()
 
     # Check that it synchronizes
     Process.sleep(100)
-    assert Nerves.Time.synchronized?()
+    assert NervesTime.synchronized?()
   end
 
   test "can set servers at runtime" do
@@ -119,15 +119,15 @@ defmodule NervesTimeTest do
 
     # No synchronization since no servers
     Process.sleep(100)
-    assert Nerves.Time.Ntpd.clean_start?()
-    refute Nerves.Time.synchronized?()
+    assert NervesTime.Ntpd.clean_start?()
+    refute NervesTime.synchronized?()
 
     # Set the servers...
-    Nerves.Time.set_ntp_servers(["1.2.3.4"])
+    NervesTime.set_ntp_servers(["1.2.3.4"])
 
     # Check that it synchronizes
     Process.sleep(100)
-    assert Nerves.Time.synchronized?()
+    assert NervesTime.synchronized?()
 
     # Use the defaults for servers for the other tests.
     Application.delete_env(:nerves_time, :servers)
@@ -139,17 +139,17 @@ defmodule NervesTimeTest do
 
     # Check synchronization with default set
     Process.sleep(100)
-    assert Nerves.Time.Ntpd.clean_start?()
-    assert Nerves.Time.synchronized?()
+    assert NervesTime.Ntpd.clean_start?()
+    assert NervesTime.synchronized?()
 
     # Change the servers...
-    Nerves.Time.set_ntp_servers(["1.2.3.4"])
+    NervesTime.set_ntp_servers(["1.2.3.4"])
 
     # Verify that we're no longer synchronized.
-    refute Nerves.Time.synchronized?()
+    refute NervesTime.synchronized?()
 
     # Check for eventual synchronization
     Process.sleep(100)
-    assert Nerves.Time.synchronized?()
+    assert NervesTime.synchronized?()
   end
 end

--- a/test/sane_time_test.exs
+++ b/test/sane_time_test.exs
@@ -1,7 +1,7 @@
 defmodule SaneTimeTest do
   use ExUnit.Case
 
-  alias Nerves.Time.SaneTime
+  alias NervesTime.SaneTime
 
   test "dates before build are adjusted" do
     before_build = NaiveDateTime.utc_now() |> Map.put(:year, 2017)


### PR DESCRIPTION
NervesTime is its own project and really shouldn't be using the Nerves
namespace.