### PR TITLE
Support reproducible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,27 @@ config :nerves_time, :servers, [
 It's also possible to configure NTP servers at runtime. See
 `NervesTime.set_ntp_servers/1`.
 
+`nerves_time` also has a concept of a valid time range. This minimizes time
+errors on systems without clocks or Internet connections or that may have some
+issue that causes a very wrong time value. The default valid time range is
+hardcoded and moves forward each release. It is not the build timestamp since
+that results in [non-reproducible builds](https://reproducible-builds.org).
+Applications can override the valid range via the application config:
+
+```elixir
+# config/config.exs
+
+config :nerves_time, earliest_time: ~N[2019-10-04 00:00:00], latest_time: ~N[2022-01-01 00:00:00]
+```
+
 ## Algorithm
 
 Here's the basic idea behind `nerves_time`:
 
-* If the clock hasn't been set or is invalid, set it to the time that
-  `nerves_time` was compiled.
+* If the clock hasn't been set or is invalid, set it to the earliest valid
+  time known to `nerves_time`. This is either set in the application config or
+  defaulted to a reasonable value that likely moves forward a little each
+  `nerves_time` release.
 * Check for `~/.nerves_time`. If it exists, advance the clock to it's last
   modification time.
 * Run Busybox `ntpd` to synchronize time using the [NTP

--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -7,6 +7,19 @@ defmodule NervesTime do
   disconnected. It's especially useful for devices lacking a [Battery-backed
   real-time clock](https://en.wikipedia.org/wiki/Real-time_clock) and will
   advance the clock at startup to a reasonable guess.
+
+  Nearly all configuration is via the application config (`config.exs`). The
+  following keys are available:
+
+  * `:servers` - a list of NTP servers for time synchronization. Specifying an
+    empty list turns off NTP
+  * `:time_file` - a file path for tracking the time. It allows the system to
+    start with a reasonable time quickly on boot and before the Internet is
+    available for NTP to work.
+  * `:earliest_time` - times before this are considered invalid and adjusted
+  * `:latest_time` - times after this are considered invalid and adjusted
+  * `:ntpd` - the absolute path to the Busybox `ntpd`. This only needs to be
+    set if your system does not provide `ntpd` in the `$PATH`.
   """
 
   @doc """

--- a/lib/nerves_time/file_time.ex
+++ b/lib/nerves_time/file_time.ex
@@ -12,16 +12,17 @@ defmodule NervesTime.FileTime do
   end
 
   @doc """
-  Return the timestamp of when update was last called.
+  Return the timestamp of when update was last called or
+  the Unix epoch time (1970-01-01) should that not work.
   """
-  @spec time() :: NaiveDateTime.t() | {:error, File.posix()}
+  @spec time() :: NaiveDateTime.t()
   def time() do
     case File.stat(time_file()) do
       {:ok, stat} ->
         NaiveDateTime.from_erl!(stat.mtime)
 
-      error ->
-        error
+      _error ->
+        ~N[1970-01-01 00:00:00]
     end
   end
 

--- a/lib/nerves_time/sane_time.ex
+++ b/lib/nerves_time/sane_time.ex
@@ -47,6 +47,11 @@ defmodule NervesTime.SaneTime do
     end
   end
 
+  # Fix anything bogus that's passed in. This does not feel very Erlang, but
+  # crashing nerves_time causes more pain than it's worth for purity.
+  def make_sane(_other),
+    do: Application.get_env(:nerves_time, :earliest_time, @default_earliest_time)
+
   defp within_interval(time, earliest_time, latest_time) do
     NaiveDateTime.compare(time, earliest_time) == :gt and
       NaiveDateTime.compare(time, latest_time) == :lt

--- a/test/sane_time_test.exs
+++ b/test/sane_time_test.exs
@@ -3,15 +3,44 @@ defmodule SaneTimeTest do
 
   alias NervesTime.SaneTime
 
-  test "dates before build are adjusted" do
-    before_build = NaiveDateTime.utc_now() |> Map.put(:year, 2017)
+  test "dates within range are not adjusted" do
+    time = ~N[2027-01-01 00:00:00]
+    sane_time = SaneTime.make_sane(time)
+    assert time == sane_time
+  end
+
+  test "dates before build are adjusted forward" do
+    before_build = ~N[2019-01-01 00:00:00]
     sane_time = SaneTime.make_sane(before_build)
     assert NaiveDateTime.compare(sane_time, before_build) == :gt
   end
 
-  test "dates way in the future are adjusted" do
-    future = NaiveDateTime.utc_now() |> Map.put(:year, 2099)
+  test "future dates are adjusted backwards" do
+    future = ~N[2099-01-01 00:00:00]
     sane_time = SaneTime.make_sane(future)
     assert NaiveDateTime.compare(sane_time, future) == :lt
+  end
+
+  test "possible to override the earliest date" do
+    distant_past = ~N[1975-01-01 00:00:00]
+    Application.put_env(:nerves_time, :earliest_time, distant_past)
+    epoch = ~N[1970-01-01 00:00:00]
+    sane_time = SaneTime.make_sane(epoch)
+    assert sane_time == distant_past
+    Application.delete_env(:nerves_time, :earliest_time)
+  end
+
+  test "possible to override the latest date" do
+    distant_past = ~N[1975-01-01 00:00:00]
+    less_distant_past = ~N[1979-01-01 00:00:00]
+
+    Application.put_env(:nerves_time, :earliest_time, distant_past)
+    Application.put_env(:nerves_time, :latest_time, less_distant_past)
+
+    sane_time = SaneTime.make_sane(NaiveDateTime.utc_now())
+    assert sane_time == distant_past
+
+    Application.delete_env(:nerves_time, :earliest_time)
+    Application.delete_env(:nerves_time, :latest_time)
   end
 end


### PR DESCRIPTION
Previously each build of `nerves_time` resulted in a different binary
due to the use of a build timestamp in sane_time.ex. This commit fixes
that so that if SOURCE_DATE_EPOCH is set, the timestampe is forced to
the specified value. See https://reproducible-builds.org for more
information.