### PR TITLE
adds support for registering time sync handlers, for example RTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ Applications can override the valid range via the application config:
 config :nerves_time, earliest_time: ~N[2019-10-04 00:00:00], latest_time: ~N[2022-01-01 00:00:00]
 ```
 
+If there are external modules that depend on knowing about time changes, for example a hardware RTC, event handlers can be specified for that:
+```elixir
+# Time sync client module
+
+handler_fun = fn(stratum) -> 
+  # ... do what needs to be done on time sync, eg. syncing a hardware RTC to system time
+end
+
+NervesTime.add_time_sync_handler(&handler_fun)
+
+```
+and handlers will be called when .
+
 ## Algorithm
 
 Here's the basic idea behind `nerves_time`:

--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -67,6 +67,13 @@ defmodule NervesTime do
   defdelegate ntp_servers(), to: NervesTime.Ntpd
 
   @doc """
+  Set tune sync handler
+  """
+  @spec add_time_sync_handler(fun()) :: :ok | {:error, term()}
+  defdelegate add_time_sync_handler(handler_fun), to: NervesTime.Ntpd
+
+
+  @doc """
   Manually restart the NTP daemon
 
   This is normally not necessary since `NervesTime` handles restarting it


### PR DESCRIPTION
This adds a mechanism for registering handlers at runtime for time sync that get called whenever time is updated through NTP. It is very simplistic, as it only allows adding, but not removing handlers, in the spirit of letting things crash in the unlikely case a registered handler dies and its handler function crashes.

Registering the callback in the `application_started` Shoehorn handler allows this to persist even when `nerves_time` is restarted intentionally or through crashes.

I've tested it with an RTC module that talks to an I2C RTC chip on `rpi0`.

A more holistic approach could integrate an RTC better, as right now `nerves_time` comes up first, and reads the timestamp file to set the system time, and then the RTC comes up with the main app and sets system time again.

See #3 